### PR TITLE
[RHICOMPL-3032] feat: create/update FloorPlan CRD

### DIFF
--- a/config/crd/bases/metrics.console.redhat.com_floorplans.yaml
+++ b/config/crd/bases/metrics.console.redhat.com_floorplans.yaml
@@ -32,9 +32,73 @@ spec:
           spec:
             description: Spec defines the desired state of FloorPlan
             type: object
-            x-kubernetes-preserve-unknown-fields: true
+            required:
+              - database
+              - envName
+              - objectStore
+              - queries
+            properties:
+              database:
+                description: The database specification ClowdApp specification.
+                type: object
+                properties:
+                  sharedDbAppName:
+                    description: Defines the Name of the app to share a database from.
+                    type: string
+                required:
+                  - sharedDbAppName
+              envName:
+                description: The name of the ClowdEnvironment resource that this ClowdApp
+                  will use as its base. This does not mean that the ClowdApp needs
+                  to be placed in the same directory as the targetNamespace of the
+                  ClowdEnvironment.
+                type: string
+              logLevel:
+                description: Sets logging level of floorist execution. See
+                  https://docs.python.org/3/library/logging.html?highlight=logging#logging-levels
+                  for expected values.
+                type: string
+                default: INFO
+              objectStore:
+                description: Object Storage (S3) configuration.
+                type: object
+                properties:
+                  bucketName:
+                    description: Bucket name where the metrics will be exported to.
+                    type: string
+                  secretName:
+                    description: Name of the object store secret containing credentials.
+                    type: string
+                required:
+                  - bucketName
+              queries:
+                description: List of Floorist queries to export as prefix-query pairs.
+                type: array
+                items:
+                  description: Floorist Query definition.
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                  properties:
+                    prefix:
+                      description: Valid folder path that will be created under the bucket.
+                      type: string
+                    query:
+                      description: A sinqle SQL query to export as metric.
+                      type: string
+                    chunksize:
+                      description:
+                      type: integer
+                  required:
+                    - prefix
+                    - query
+              suspend:
+                description: This flag tells the controller to suspend subsequent
+                  executions, it does not apply to already started executions.  Defaults
+                  to false. Only applies to Cronjobs
+                type: boolean
+                default: false
           status:
-            description: Status defines the observed state of FloorPlan
+            description: Status defines the observed state of FloorPlan.
             type: object
             x-kubernetes-preserve-unknown-fields: true
         type: object

--- a/config/samples/metrics_v1alpha1_floorplan.yaml
+++ b/config/samples/metrics_v1alpha1_floorplan.yaml
@@ -3,4 +3,17 @@ kind: FloorPlan
 metadata:
   name: floorplan-sample
 spec:
-  # TODO(user): Add fields here
+  queries:
+  - prefix: dumps/people
+    query: >-
+      SELECT name, email, birthyear FROM people;
+  - prefix: dumps/cities
+    query: >-
+      SELECT name AS city_name, zip, country FROM cities;
+    chunksize: 100
+  envName: env-default
+  database:
+    sharedDbAppName: mydatabase
+  objectStore:
+    bucketName: mybucket
+    secretName: metrics-export

--- a/roles/floorplan/defaults/main.yml
+++ b/roles/floorplan/defaults/main.yml
@@ -1,2 +1,8 @@
 ---
 # defaults file for FloorPlan
+queries: []
+database:
+  sharedDbAppName:
+objectStore:
+  bucketName:
+  secretName: metrics-export


### PR DESCRIPTION
Updates scaffolded FloorPlan CRD to be similar to Floorist floorplan.yaml.

Testing:
There is an automatic Molecule test generated. Once we know how to use it we can test this manually.

1. Apply CRD
    ```
    kubectl apply -f config/crd/bases/metrics.console.redhat.com_floorplans.yaml
    ```
2. Check existence of the CRD
    ```
    kubectl get crd floorplans.metrics.console.redhat.com -o yaml
    ```
3. Apply sample to a default namespace (can be a dry-run)
    ```
    kubectl apply -f config/samples/metrics_v1alpha1_floorplan.yaml [--dry-run=server]
    ```

RHICOMPL-3032 