### PR TITLE
[RHICOMPL-3033] feat: main Ansible task setting up the schedule

### DIFF
--- a/config/clowder/bases/clowdenv.yaml
+++ b/config/clowder/bases/clowdenv.yaml
@@ -1,0 +1,51 @@
+---
+apiVersion: cloud.redhat.com/v1alpha1
+# Custom Resource defined as part of the Clowder API
+kind: ClowdEnvironment
+metadata:
+  name: env-default
+spec:
+  targetNamespace: default
+
+  # Providers all your app to consume configuration
+  # data automatically based on your request
+  providers:
+
+    # provides a k8s service on port 8000
+    web:
+      port: 8000
+      privatePort: 8080
+      mode: operator
+
+    # provides a prometheus metrics port on 9000
+    metrics:
+      port: 9000
+      mode: operator
+      path: "/metrics"
+
+    kafka:
+      mode: none
+
+    # Clowder supports postgres 10 and 12. Specify the name
+    # and other details in the clowdapp
+    db:
+      mode: local
+
+    logging:
+      mode: none
+
+    # Deploys a local minio pod for object storage
+    objectStore:
+      mode: minio
+
+    inMemoryDb:
+      mode: none
+
+  resourceDefaults:
+    limits:
+      cpu: "500m"
+      memory: "8192Mi"
+    requests:
+      cpu: "300m"
+      memory: "1024Mi"
+

--- a/config/clowder/bases/test-clowdapp.yaml
+++ b/config/clowder/bases/test-clowdapp.yaml
@@ -1,0 +1,88 @@
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: ClowdApp
+metadata:
+  name: test-app
+  namespace: default
+spec:
+  # The name of the ClowdEnvironment providing the services
+  envName: env-default
+
+  deployments:
+  - name: service
+    minReplicas: 1
+    podSpec:
+      image: docker.io/postgres:12
+      command: ["/bin/bash"]
+      args: ["-c", "/tmp/app.sh"]
+      env:
+      - name: PGHOST
+        valueFrom:
+          secretKeyRef:
+            name: test-app-db
+            key: hostname
+      - name:  PGDATABASE
+        valueFrom:
+          secretKeyRef:
+            name: test-app-db
+            key: name
+      - name: PGPASSWORD
+        valueFrom:
+          secretKeyRef:
+            name: test-app-db
+            key: password
+      - name:  PGPORT
+        valueFrom:
+          secretKeyRef:
+            name: test-app-db
+            key: port
+      - name: PGUSER
+        valueFrom:
+          secretKeyRef:
+            name: test-app-db
+            key: username
+      resources:
+        limits:
+          cpu: 50m
+          memory: 100Mi
+        requests:
+          cpu: 20m
+          memory: 50Mi
+      volumeMounts:
+      - name: app-script-volume
+        mountPath: /tmp
+      volumes:
+        - name: app-script-volume
+          configMap:
+            name: app-script
+            defaultMode: 0755
+
+  database:
+    # Must specify both a name and a major postgres version
+    name: mydatabase
+    version: 12
+
+  objectStore:
+  - mybucket
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app-script
+  namespace: default
+data:
+  app.sh: |
+    set -e
+    psql <<EOF
+      CREATE TABLE people (name VARCHAR(255), email VARCHAR(255), birthyear INT);
+      INSERT INTO people VALUES
+        ('My Name', 'My Email', 9999),
+        ('Your Name', 'Your Email', 1111);
+      CREATE TABLE cities (name VARCHAR(255), zip VARCHAR(255), country VARCHAR(255));
+      INSERT INTO cities VALUES
+        ('Ney York', '900 22', 'USA'),
+        ('Rio', '111 88', 'Brazil'),
+        ('Tokyo', '91378', 'Japan');
+    EOF
+
+    sleep infinity

--- a/config/clowder/kustomization.yaml
+++ b/config/clowder/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+- bases/clowdenv.yaml
+- bases/test-clowdapp.yaml

--- a/config/clowder/minio/minio_secret_consitency.yaml
+++ b/config/clowder/minio/minio_secret_consitency.yaml
@@ -1,0 +1,18 @@
+# Apply via patch as jsonpatch using:
+# kubectl patch secret env-default-minio --type=json --patch-file config/clowder/minio/minio_secret_consitency.yaml
+---
+- op: add
+  path: /data/bucket
+  value: bXlidWNrZXQ=
+- op: add
+  path: /data/aws_region
+  value: bG9jYWw=
+- op: add
+  path: /data/endpoint
+  value: aHR0cDovL2Vudi1kZWZhdWx0LW1pbmlvLmRlZmF1bHQuc3ZjOjkwMDA=
+- op: copy
+  from: /data/accessKey
+  path: /data/aws_access_key_id
+- op: copy
+  from: /data/secretKey
+  path: /data/aws_secret_access_key

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -25,6 +25,14 @@ patchesStrategicMerge:
 # endpoint w/o any authn/z, please comment the following line.
 - manager_auth_proxy_patch.yaml
 
+patchesJson6902:
+- path: patches/floorist_image_tag.config.yaml
+  target:
+    group: apps
+    version: v1
+    kind: Deployment
+    name: controller-manager
+
 # Mount the controller config file for loading manager configurations
 # through a ComponentConfig type
 #- manager_config_patch.yaml

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -9,6 +9,12 @@ spec:
   template:
     spec:
       containers:
+      - name: manager
+        args:
+        - "--health-probe-bind-address=:6789"
+        - "--metrics-bind-address=127.0.0.1:8080"
+        - "--leader-elect"
+        - "--leader-election-id=floorist-operator"
       - name: kube-rbac-proxy
         image: gcr.io/kubebuilder/kube-rbac-proxy:v0.11.0
         args:
@@ -27,9 +33,3 @@ spec:
           requests:
             cpu: 5m
             memory: 64Mi
-      - name: manager
-        args:
-        - "--health-probe-bind-address=:6789"
-        - "--metrics-bind-address=127.0.0.1:8080"
-        - "--leader-elect"
-        - "--leader-election-id=floorist-operator"

--- a/config/default/patches/floorist_image_tag.config.yaml
+++ b/config/default/patches/floorist_image_tag.config.yaml
@@ -1,0 +1,3 @@
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: --ansible-args='--extra-vars "floorist_image_tag=a5d1b1b"'

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -14,6 +14,7 @@ rules:
       - pods
       - pods/exec
       - pods/log
+      - configmaps
     verbs:
       - create
       - delete

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -38,6 +38,19 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+      - cloud.redhat.com
+    resources:
+      - clowdapps
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  ##
   ##
   ## Rules for metrics.console.redhat.com/v1alpha1, Kind: FloorPlan
   ##

--- a/config/samples/metrics_v1alpha1_floorplan.yaml
+++ b/config/samples/metrics_v1alpha1_floorplan.yaml
@@ -13,7 +13,7 @@ spec:
     chunksize: 100
   envName: env-default
   database:
-    sharedDbAppName: mydatabase
+    sharedDbAppName: test-app
   objectStore:
     bucketName: mybucket
-    secretName: metrics-export
+    secretName: env-default-minio

--- a/roles/floorplan/defaults/main.yml
+++ b/roles/floorplan/defaults/main.yml
@@ -1,5 +1,7 @@
 ---
 # defaults file for FloorPlan
+floorist_image_tag: latest
+env_name: env-default
 queries: []
 database:
   sharedDbAppName:

--- a/roles/floorplan/meta/main.yml
+++ b/roles/floorplan/meta/main.yml
@@ -1,8 +1,8 @@
 ---
 galaxy_info:
-  author: your name
-  description: your description
-  company: your company (optional)
+  author: Red Hat Insights
+  description: Floorist Operator for metrics exports to S3 buckets
+  company: Red Hat
 
   # If the issue tracker for your role is not on github, uncomment the
   # next line and provide a value
@@ -15,7 +15,7 @@ galaxy_info:
   # - GPLv3
   # - Apache
   # - CC-BY
-  license: license (GPLv2, CC-BY, etc)
+  license: Apache 2.0
 
   min_ansible_version: 2.9
 

--- a/roles/floorplan/tasks/main.yml
+++ b/roles/floorplan/tasks/main.yml
@@ -1,2 +1,12 @@
 ---
 # tasks file for FloorPlan
+- name: set up floorplan
+  kubernetes.core.k8s:
+    definition:
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: '{{ ansible_operator_meta.name }}-floorplan'
+        namespace: '{{ ansible_operator_meta.namespace }}'
+      data:
+        floorplan.yaml: '{{ queries | to_nice_yaml }}'

--- a/roles/floorplan/tasks/main.yml
+++ b/roles/floorplan/tasks/main.yml
@@ -10,3 +10,72 @@
         namespace: '{{ ansible_operator_meta.namespace }}'
       data:
         floorplan.yaml: '{{ queries | to_nice_yaml }}'
+- name: set up floorist schedule
+  kubernetes.core.k8s:
+    apply: yes
+    definition:
+      apiVersion: cloud.redhat.com/v1alpha1
+      kind: ClowdApp
+      metadata:
+        name: '{{ ansible_operator_meta.name }}-floorist'
+        namespace: '{{ ansible_operator_meta.namespace }}'
+      spec:
+        database:
+          sharedDbAppName: '{{ database.shared_db_app_name }}'
+        dependencies:
+          - '{{ database.shared_db_app_name }}'
+        envName: '{{ env_name }}'
+        jobs:
+        - name: metrics-exporter
+          suspend: "{{ suspend }}"
+          schedule: "0 2 * * *"
+          concurrencyPolicy: Forbid
+          podSpec:
+            image: 'quay.io/cloudservices/floorist:{{ floorist_image_tag }}'
+            env:
+            - name: AWS_BUCKET
+              valueFrom:
+                secretKeyRef:
+                  name: '{{ object_store.secret_name }}'
+                  key: bucket
+            - name: AWS_REGION
+              valueFrom:
+                secretKeyRef:
+                  name: '{{ object_store.secret_name }}'
+                  key: aws_region
+            - name: AWS_ENDPOINT
+              valueFrom:
+                secretKeyRef:
+                  name: '{{ object_store.secret_name }}'
+                  key: endpoint
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: '{{ object_store.secret_name }}'
+                  key: aws_access_key_id
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: '{{ object_store.secret_name }}'
+                  key: aws_secret_access_key
+            - name: FLOORPLAN_FILE
+              value: "/tmp/floorplan/floorplan.yaml"
+            - name: LOGLEVEL
+              value: '{{ log_level }}'
+            livenessProbe:
+              exec:
+                command: ["pgrep", "-f", "run"]
+            volumeMounts:
+            - name: floorplan-volume
+              mountPath: "/tmp/floorplan"
+            volumes:
+              - name: floorplan-volume
+                configMap:
+                  name: '{{ ansible_operator_meta.name }}-floorplan'
+            resources:
+              limits:
+                cpu: 100m
+                memory: 200Mi
+              requests:
+                cpu: 50m
+                memory: 100Mi


### PR DESCRIPTION
Adds in the core of the operator, adding main Ansible task that creates necessary k8s resources (`ConfigMap` and `ClowdApp`). Clowder test environment YAMLs, incl. a test app, are provided.

Test instructions:
1. Install [Clowder Operator](https://github.com/RedHatInsights/clowder#getting-clowder) into minikube:
   1. Run [`build/kube_setup.sh`](https://github.com/RedHatInsights/clowder/blob/master/build/kube_setup.sh)
   2. Apply manifest
      ```
      minikube kubectl -- apply -f https://github.com/RedHatInsights/clowder/releases/download/v0.32.0/clowder-manifest-v0.32.0.yaml --validate=false
      ```
2. Build, push, and deploy floorist-operator
   ```
   VERSION=0.0.1-1 make podman-build podman-push deploy
   ```
3. Setup test app on default env
   ```
   minikube kubectl -- apply -k config/clowder
   ```
4. Wait for `env-default-minio` secret presence
5. Patch `env-default-minio` secret to be consitent with AWS
   ```
   minikube kubectl -- patch secret env-default-minio --type=json --patch-file config/clowder/minio/minio_secret_consitency.yaml
   ```
6. Apply sample `Floorplan`
   ```
   minikube kubectl -- apply -f config/samples/metrics_v1alpha1_floorplan.yaml
   ```
7. Observe exisence of `floorplan-sample-floorist` ClowdApp
   ```
   $ minikube kubectl -- get app floorplan-sample-floorist
   NAME                        READY   MANAGED   ENVNAME       AGE
   floorplan-sample-floorist   0       0         env-default   146m
   ```
   The two zeroes are okay!
8. Run the `floorplan-sample-floorist-metrics-exporter` CronJob manually
9. Observe run of the worker pod

RHICOMPL-3033