### PR TITLE
[RHICOMPL-3037] feat: dynamic scheduling with configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Kubernetes Operator to manage scheduling of metrics export with [Floorist](https
 ## TOC
 
 1. [Description](#description)
+   1. [Scheduling](#scheduling)
 2. [Installation](#installation)
 3. [Usage](#usage)
 4. [Development](#development)
@@ -27,10 +28,25 @@ with a daily schedule.
 Advantages of having Floorist managed within operator are:
 * central configuration of Floorist version/image managed across all namespaces,
 * ease of configuration,
-* dynamic scheduling (*FutureFeature).
+* dynamic scheduling
 
 The operator is build using [Ansible Operator SDK](https://sdk.operatorframework.io/docs/building-operators/ansible/)
 leveraging [kubernetes.core.k8s](https://docs.ansible.com/ansible/latest/collections/kubernetes/core/k8s_module.html) Ansible module.
+
+### Scheduling
+
+Each `FloorPlan` resource/instace will get a non-conflicting schedule assigned.
+Schedule assignement is selected as the first available slot during a day in a predefined interval.
+By default this interval is 5 minutes, configured via `schedule_step` Ansible variable (max value is 60).
+
+Midninght (00:00) is by default reserved.
+The first schedule starts at `00:05` (with default 5 min. interval).
+Slot constraints can be set via `skip_schedules` Ansible variable.
+
+There is an upper limit on the number of `FloorPlan`s which is by default **287**.
+The formula for different settings is: `24 * (60 / schedule_step)`.
+
+Schedule of a single `FloorPlan` stays constant for the whole duration of its lifetime.
 
 ## Installation
 

--- a/roles/floorplan/defaults/main.yml
+++ b/roles/floorplan/defaults/main.yml
@@ -2,6 +2,8 @@
 # defaults file for FloorPlan
 floorist_image_tag: latest
 schedule_step: 5 # in minutes (max 60)
+skip_schedules: # list of schedules that should be skipped, strings of 'min hr'
+  - '0 0'
 env_name: env-default
 queries: []
 database:

--- a/roles/floorplan/defaults/main.yml
+++ b/roles/floorplan/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 # defaults file for FloorPlan
 floorist_image_tag: latest
+schedule_step: 5 # in minutes (max 60)
 env_name: env-default
 queries: []
 database:

--- a/roles/floorplan/tasks/main.yml
+++ b/roles/floorplan/tasks/main.yml
@@ -27,7 +27,7 @@
     # Hours are generated first, but then swapped, to ensure sequence.
     available_slots:
       "{{ range(0, 24)
-          | product(range(0, 60, 5))
+          | product(range(0, 60, schedule_step))
           | map('join', ' ')
           | map('regex_replace', '^([^ ]+) ([^ ]+)$', '\\2 \\1')
           | list

--- a/roles/floorplan/tasks/main.yml
+++ b/roles/floorplan/tasks/main.yml
@@ -10,9 +10,32 @@
         namespace: '{{ ansible_operator_meta.namespace }}'
       data:
         floorplan.yaml: '{{ queries | to_nice_yaml }}'
+- name: gather facts from existing floorplans
+  ansible.builtin.set_fact:
+    existing_schedule: "{{ _metrics_console_redhat_com_floorplan.get('status', {}).get('schedule') }}"
+    # Gather used schedules from all FloorPlans from status.schedule attribute,
+    # taking only mintues and hours.
+    used_slots:
+      "{{ query('kubernetes.core.k8s', api_version='metrics.console.redhat.com/v1alpha1', kind='FloorPlan')
+          | map(attribute='status', default={})
+          | map(attribute='schedule', default='')
+          | map('regex_replace', '^([^ ]+) ([^ ]+).*$', '\\1 \\2')
+          | list
+        }}"
+    # Generate available schedules as a product of hours and mintues
+    # with a certain step.
+    # Hours are generated first, but then swapped, to ensure sequence.
+    available_slots:
+      "{{ range(0, 24)
+          | product(range(0, 60, 5))
+          | map('join', ' ')
+          | map('regex_replace', '^([^ ]+) ([^ ]+)$', '\\2 \\1')
+          | list
+        }}"
 - name: set schedule fact
   ansible.builtin.set_fact:
-    schedule: "0 2 * * *"
+    schedule:
+      "{{ existing_schedule | default((available_slots | difference(used_slots) | first) + ' * * *', true) }}"
 - name: set up floorist schedule
   kubernetes.core.k8s:
     apply: yes

--- a/roles/floorplan/tasks/main.yml
+++ b/roles/floorplan/tasks/main.yml
@@ -82,3 +82,11 @@
               requests:
                 cpu: 50m
                 memory: 100Mi
+- name: set schedule status
+  operator_sdk.util.k8s_status:
+    api_version: metrics.console.redhat.com/v1alpha1
+    kind: FloorPlan
+    name: "{{ ansible_operator_meta.name }}"
+    namespace: "{{ ansible_operator_meta.namespace }}"
+    status:
+      schedule: "{{ schedule }}"

--- a/roles/floorplan/tasks/main.yml
+++ b/roles/floorplan/tasks/main.yml
@@ -10,6 +10,9 @@
         namespace: '{{ ansible_operator_meta.namespace }}'
       data:
         floorplan.yaml: '{{ queries | to_nice_yaml }}'
+- name: set schedule fact
+  ansible.builtin.set_fact:
+    schedule: "0 2 * * *"
 - name: set up floorist schedule
   kubernetes.core.k8s:
     apply: yes
@@ -28,7 +31,7 @@
         jobs:
         - name: metrics-exporter
           suspend: "{{ suspend }}"
-          schedule: "0 2 * * *"
+          schedule: "{{ schedule }}"
           concurrencyPolicy: Forbid
           podSpec:
             image: 'quay.io/cloudservices/floorist:{{ floorist_image_tag }}'

--- a/roles/floorplan/tasks/main.yml
+++ b/roles/floorplan/tasks/main.yml
@@ -30,6 +30,7 @@
           | product(range(0, 60, schedule_step))
           | map('join', ' ')
           | map('regex_replace', '^([^ ]+) ([^ ]+)$', '\\2 \\1')
+          | difference(skip_schedules)
           | list
         }}"
 - name: set schedule fact


### PR DESCRIPTION
Each floorist schedules are now being set to be 5 minutes apart from 00:05.
Existing FloorPlans would keep their schedule intact by storing its value on the resource status.
There is a limitation of number of schedules/floorplans, currently 287.

The scheduling behavior is controlled by these Ansible variables:
* `schedule_step` (defaults to 5, max 60)
* `skip_schedules` (defaults to `['0 0']`)

RHICOMPL-3037