### PR TITLE
[RHICOMPL-3077] fix: use minimal role rules

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -10,26 +10,7 @@ rules:
   - apiGroups:
       - ""
     resources:
-      - secrets
-      - pods
-      - pods/exec
-      - pods/log
       - configmaps
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - apps
-    resources:
-      - deployments
-      - daemonsets
-      - replicasets
-      - statefulsets
     verbs:
       - create
       - delete

--- a/deploy_template.yaml
+++ b/deploy_template.yaml
@@ -159,26 +159,7 @@ objects:
   - apiGroups:
     - ''
     resources:
-    - secrets
-    - pods
-    - pods/exec
-    - pods/log
     - configmaps
-    verbs:
-    - create
-    - delete
-    - get
-    - list
-    - patch
-    - update
-    - watch
-  - apiGroups:
-    - apps
-    resources:
-    - deployments
-    - daemonsets
-    - replicasets
-    - statefulsets
     verbs:
     - create
     - delete


### PR DESCRIPTION
Require to use minimal set of role rules for the operator manager.

RHICOMPL-3077