### PR TITLE
[RHICOMPL-3050] fix: minimal deployment resources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,7 @@ endif
 
 .PHONY: openshift-template
 openshift-template: kustomize
-	$(KUSTOMIZE) build config/default | \
+	$(KUSTOMIZE) build config/templated | \
 	config/plugins/openshift_template_generator.rb config/templated/template_params.yaml \
 	> "${OPENSHIFT_TEMPLATE}"
 

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -16,7 +16,7 @@ bases:
 - ../crd
 - ../rbac
 - namespace.yaml
-- ../proxied_manager
+- ../manager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
 

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -12,7 +12,7 @@ resources:
 # Comment the following 4 lines if you want to disable
 # the auth proxy (https://github.com/brancz/kube-rbac-proxy)
 # which protects your /metrics endpoint.
-- auth_proxy_service.yaml
-- auth_proxy_role.yaml
-- auth_proxy_role_binding.yaml
-- auth_proxy_client_clusterrole.yaml
+# - auth_proxy_service.yaml
+# - auth_proxy_role.yaml
+# - auth_proxy_role_binding.yaml
+# - auth_proxy_client_clusterrole.yaml

--- a/config/templated/kustomization.yaml
+++ b/config/templated/kustomization.yaml
@@ -6,7 +6,7 @@ namePrefix: floorist-operator-
 resources:
 - ../crd
 - ../rbac
-- ../proxied_manager
+- ../manager
 
 patchesJson6902:
 - path: manager_params.config.yaml

--- a/deploy_template.yaml
+++ b/deploy_template.yaml
@@ -195,32 +195,6 @@ objects:
     - update
     - watch
 - apiVersion: rbac.authorization.k8s.io/v1
-  kind: ClusterRole
-  metadata:
-    name: floorist-operator-metrics-reader
-  rules:
-  - nonResourceURLs:
-    - "/metrics"
-    verbs:
-    - get
-- apiVersion: rbac.authorization.k8s.io/v1
-  kind: ClusterRole
-  metadata:
-    name: floorist-operator-proxy-role
-  rules:
-  - apiGroups:
-    - authentication.k8s.io
-    resources:
-    - tokenreviews
-    verbs:
-    - create
-  - apiGroups:
-    - authorization.k8s.io
-    resources:
-    - subjectaccessreviews
-    verbs:
-    - create
-- apiVersion: rbac.authorization.k8s.io/v1
   kind: RoleBinding
   metadata:
     name: floorist-operator-leader-election-rolebinding
@@ -245,18 +219,6 @@ objects:
   - kind: ServiceAccount
     name: floorist-operator-controller-manager
     namespace: floorist-operator-system
-- apiVersion: rbac.authorization.k8s.io/v1
-  kind: ClusterRoleBinding
-  metadata:
-    name: floorist-operator-proxy-rolebinding
-  roleRef:
-    apiGroup: rbac.authorization.k8s.io
-    kind: ClusterRole
-    name: floorist-operator-proxy-role
-  subjects:
-  - kind: ServiceAccount
-    name: floorist-operator-controller-manager
-    namespace: floorist-operator-system
 - apiVersion: v1
   data:
     controller_manager_config.yaml: |
@@ -274,21 +236,6 @@ objects:
   metadata:
     name: floorist-operator-manager-config
     namespace: floorist-operator-system
-- apiVersion: v1
-  kind: Service
-  metadata:
-    labels:
-      control-plane: controller-manager
-    name: floorist-operator-controller-manager-metrics-service
-    namespace: floorist-operator-system
-  spec:
-    ports:
-    - name: https
-      port: 8443
-      protocol: TCP
-      targetPort: https
-    selector:
-      control-plane: controller-manager
 - apiVersion: apps/v1
   kind: Deployment
   metadata:
@@ -310,8 +257,6 @@ objects:
       spec:
         containers:
         - args:
-          - "--health-probe-bind-address=:6789"
-          - "--metrics-bind-address=127.0.0.1:8080"
           - "--leader-elect"
           - "--leader-election-id=floorist-operator"
           - --ansible-args='--extra-vars "floorist_image_tag=a5d1b1b"'
@@ -341,24 +286,6 @@ objects:
               memory: 256Mi
           securityContext:
             allowPrivilegeEscalation: false
-        - args:
-          - "--secure-listen-address=0.0.0.0:8443"
-          - "--upstream=http://127.0.0.1:8080/"
-          - "--logtostderr=true"
-          - "--v=0"
-          image: gcr.io/kubebuilder/kube-rbac-proxy:v0.11.0
-          name: kube-rbac-proxy
-          ports:
-          - containerPort: 8443
-            name: https
-            protocol: TCP
-          resources:
-            limits:
-              cpu: 500m
-              memory: 128Mi
-            requests:
-              cpu: 5m
-              memory: 64Mi
         securityContext:
           runAsNonRoot: true
         serviceAccountName: floorist-operator-controller-manager

--- a/deploy_template.yaml
+++ b/deploy_template.yaml
@@ -4,12 +4,6 @@ kind: Template
 metadata:
   name: floorist-operator
 objects:
-- apiVersion: v1
-  kind: Namespace
-  metadata:
-    labels:
-      control-plane: controller-manager
-    name: floorist-operator-system
 - apiVersion: apiextensions.k8s.io/v1
   kind: CustomResourceDefinition
   metadata:
@@ -259,11 +253,11 @@ objects:
         - args:
           - "--leader-elect"
           - "--leader-election-id=floorist-operator"
-          - --ansible-args='--extra-vars "floorist_image_tag=a5d1b1b"'
+          - --ansible-args='--extra-vars "floorist_image_tag=${FLOORIST_IMAGE_TAG}"'
           env:
           - name: ANSIBLE_GATHERING
             value: explicit
-          image: quay.io/cloudservices/floorist-operator:latest
+          image: "${IMAGE}:${IMAGE_TAG}"
           livenessProbe:
             httpGet:
               path: "/healthz"


### PR DESCRIPTION
* disables RBAC proxy on the manager
* fixes OpenShift template generator to use correct kustomized objects

TODO:
- [x] test with the generated OpenShift template

RHICOMPL-3050