### PR TITLE
[RHICOMPL-3091] feat(config): FloorPlan view and editor roles

### DIFF
--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -9,6 +9,9 @@ resources:
 - role_binding.yaml
 - leader_election_role.yaml
 - leader_election_role_binding.yaml
+# FloorPlan ClusterRoles
+- floorplan_viewer_role.yaml
+- floorplan_editor_role.yaml
 # Comment the following 4 lines if you want to disable
 # the auth proxy (https://github.com/brancz/kube-rbac-proxy)
 # which protects your /metrics endpoint.

--- a/deploy_template.yaml
+++ b/deploy_template.yaml
@@ -148,6 +148,48 @@ objects:
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRole
   metadata:
+    name: floorist-operator-floorplan-editor-role
+  rules:
+  - apiGroups:
+    - metrics.console.redhat.com
+    resources:
+    - floorplans
+    verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - metrics.console.redhat.com
+    resources:
+    - floorplans/status
+    verbs:
+    - get
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRole
+  metadata:
+    name: floorist-operator-floorplan-viewer-role
+  rules:
+  - apiGroups:
+    - metrics.console.redhat.com
+    resources:
+    - floorplans
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - metrics.console.redhat.com
+    resources:
+    - floorplans/status
+    verbs:
+    - get
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRole
+  metadata:
     name: floorist-operator-manager-role
   rules:
   - apiGroups:


### PR DESCRIPTION
Exposes/adds FloorPlan roles:
* `floorist-operator-floorplan-editor-role`
* `floorist-operator-floorplan-viewer-role`

These can be then assigned accordingly.

RHICOMPL-3091