### PR TITLE
[RHICOMPL-3112] fix: default-service-account kube-lint rule

### DIFF
--- a/roles/floorplan/tasks/main.yml
+++ b/roles/floorplan/tasks/main.yml
@@ -50,6 +50,8 @@
           app: '{{ ansible_operator_meta.name }}-floorist'
           pod: 'floorist-{{ ansible_operator_meta.name }}-exporter'
           service: floorist
+        annotations:
+          ignore-check.kube-linter.io/default-service-account: "not used, k8s API access not required"
       spec:
         concurrencyPolicy: Forbid
         failedJobsHistoryLimit: 1

--- a/roles/floorplan/tasks/main.yml
+++ b/roles/floorplan/tasks/main.yml
@@ -69,6 +69,7 @@
               spec:
                 restartPolicy: Never
                 terminationGracePeriodSeconds: 30
+                automountServiceAccountToken: false
                 containers:
                 - image: 'quay.io/cloudservices/floorist:{{ floorist_image_tag }}'
                   imagePullPolicy: IfNotPresent


### PR DESCRIPTION
Disables `automountServiceAccountToken` and adds annotation to disable default-service-account kube-linter rule on floorist CronJobs.
Access to k8s API is not required for these resources.

TODO:
- [x] Test in minikube

RHICOMPL-3112