### PR TITLE
fix(manager): no min-three-replicas lint rule

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -15,6 +15,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
+        ignore-check.kube-linter.io/minimum-three-replicas: "minimum three replicas not required"
       labels:
         control-plane: controller-manager
     spec:

--- a/deploy_template.yaml
+++ b/deploy_template.yaml
@@ -292,6 +292,8 @@ objects:
     template:
       metadata:
         annotations:
+          ignore-check.kube-linter.io/minimum-three-replicas: minimum three replicas
+            not required
           kubectl.kubernetes.io/default-container: manager
         labels:
           control-plane: controller-manager


### PR DESCRIPTION
One replica for the manager pod is enough.
Supressing the lint warning.

RHICOMPL-3086