### PR TITLE
chore: update sdk to ver 1.22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/operator-framework/ansible-operator:v1.21.0
+FROM quay.io/operator-framework/ansible-operator:v1.22
 
 COPY requirements.yml ${HOME}/requirements.yml
 RUN ansible-galaxy collection install -r ${HOME}/requirements.yml \


### PR DESCRIPTION
New version, new (no) problems.

RHICOMPL-3121