### PR TITLE
feat: floorist img and tag via env var

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -20,14 +20,6 @@ bases:
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
 
-patchesJson6902:
-- path: patches/floorist_image_tag.config.yaml
-  target:
-    group: apps
-    version: v1
-    kind: Deployment
-    name: controller-manager
-
 # Mount the controller config file for loading manager configurations
 # through a ComponentConfig type
 #- manager_config_patch.yaml

--- a/config/default/patches/floorist_image_tag.config.yaml
+++ b/config/default/patches/floorist_image_tag.config.yaml
@@ -1,3 +1,0 @@
-- op: add
-  path: /spec/template/spec/containers/0/args/-
-  value: --ansible-args='--extra-vars "floorist_image_tag=a5d1b1b"'

--- a/config/templated/manager_params.config.yaml
+++ b/config/templated/manager_params.config.yaml
@@ -2,5 +2,12 @@
   path: /spec/template/spec/containers/0/image
   value: ${IMAGE}:${IMAGE_TAG}
 - op: add
-  path: /spec/template/spec/containers/0/args/-
-  value: --ansible-args='--extra-vars "floorist_image_tag=${FLOORIST_IMAGE_TAG}"'
+  path: /spec/template/spec/containers/0/env/-
+  value:
+    name: FLOORIST_IMAGE
+    value: "${FLOORIST_IMAGE}"
+- op: add
+  path: /spec/template/spec/containers/0/env/-
+  value:
+    name: FLOORIST_IMAGE_TAG
+    value: "${FLOORIST_IMAGE_TAG}"

--- a/config/templated/template_params.yaml
+++ b/config/templated/template_params.yaml
@@ -4,6 +4,9 @@
 - description: Operator image tag
   name: IMAGE_TAG
   value: latest
-- description: Floorist extractor tool image tag
+- description: Floorist exporter tool image
+  name: FLOORIST_IMAGE
+  value: quay.io/cloudservices/floorist
+- description: Floorist exporter tool image tag
   name: FLOORIST_IMAGE_TAG
-  value: latest
+  value: a5d1b1b

--- a/deploy_template.yaml
+++ b/deploy_template.yaml
@@ -302,10 +302,13 @@ objects:
         - args:
           - "--leader-elect"
           - "--leader-election-id=floorist-operator"
-          - --ansible-args='--extra-vars "floorist_image_tag=${FLOORIST_IMAGE_TAG}"'
           env:
           - name: ANSIBLE_GATHERING
             value: explicit
+          - name: FLOORIST_IMAGE
+            value: "${FLOORIST_IMAGE}"
+          - name: FLOORIST_IMAGE_TAG
+            value: "${FLOORIST_IMAGE_TAG}"
           image: "${IMAGE}:${IMAGE_TAG}"
           livenessProbe:
             httpGet:
@@ -340,6 +343,9 @@ parameters:
 - description: Operator image tag
   name: IMAGE_TAG
   value: latest
+- description: Floorist extractor tool image
+  name: FLOORIST_IMAGE
+  value: quay.io/cloudservices/floorist
 - description: Floorist extractor tool image tag
   name: FLOORIST_IMAGE_TAG
-  value: latest
+  value: a5d1b1b

--- a/roles/floorplan/defaults/main.yml
+++ b/roles/floorplan/defaults/main.yml
@@ -1,6 +1,5 @@
 ---
 # defaults file for FloorPlan
-floorist_image_tag: latest
 schedule_step: 5 # in minutes (max 60)
 skip_schedules: # list of schedules that should be skipped, strings of 'min hr'
   - '0 0'

--- a/roles/floorplan/tasks/main.yml
+++ b/roles/floorplan/tasks/main.yml
@@ -73,7 +73,9 @@
                 terminationGracePeriodSeconds: 30
                 automountServiceAccountToken: false
                 containers:
-                - image: 'quay.io/cloudservices/floorist:{{ floorist_image_tag }}'
+                - image:
+                    "{{ lookup('ansible.builtin.env', 'FLOORIST_IMAGE') | default('quay.io/cloudservices/floorist', True) }}\
+                    :{{ lookup('ansible.builtin.env', 'FLOORIST_IMAGE_TAG') | default('a5d1b1b', True) }}"
                   imagePullPolicy: IfNotPresent
                   env:
                   - name: AWS_BUCKET


### PR DESCRIPTION
Adds support to set Floorist image and tag via two environment variables, `FLOORIST_IMAGE` and `FLOORIST_IMAGE_TAG`.

RHICOMPL-3035