### PR TITLE
fix(manager): no min-three-replicas lint rule

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -6,6 +6,8 @@ metadata:
   namespace: system
   labels:
     control-plane: controller-manager
+  annotations:
+    ignore-check.kube-linter.io/minimum-three-replicas: "minimum three replicas not required"
 spec:
   selector:
     matchLabels:

--- a/deploy_template.yaml
+++ b/deploy_template.yaml
@@ -295,6 +295,9 @@ objects:
 - apiVersion: apps/v1
   kind: Deployment
   metadata:
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas: minimum three replicas not
+        required
     labels:
       control-plane: controller-manager
     name: floorist-operator-controller-manager


### PR DESCRIPTION
One replica for the manager pod is enough.
Supressing the lint warning.

(Take 2)

RHICOMPL-3239 RHICOMPL-3238