### PR TITLE
ci: automate floorist image tag updates

### DIFF
--- a/.github/workflows/checkimages.yaml
+++ b/.github/workflows/checkimages.yaml
@@ -27,3 +27,32 @@ jobs:
         uses: peter-evans/create-pull-request@v4
         with:
           title: 'chore(image): update base image'
+  latest-floorist:
+    name: Check latest Floorist image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Install skopeo, jq, and kustomize
+        run: sudo apt-get install -y skopeo jq
+      - name: Get and set latest Floorist image
+        run: |
+          tag=$(curl -s -H 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+            https://api.github.com/repos/RedHatInsights/floorist/branches/master \
+            | jq -r '.commit.sha' \
+            | cut -c1-7)
+          [[ "$tag" != "null" && "$tag" != "" ]]
+          skopeo inspect "docker://quay.io/cloudservices/floorist:$tag" > /dev/null
+          sed -i "/name: FLOORIST_IMAGE_TAG/{n;s/value: .*/value: '$tag'/}" \
+            config/templated/template_params.yaml
+          make openshift-template
+      - name: Commit changes (if any)
+        run: |
+          git config user.name 'Update-a-Bot'
+          git config user.email 'insights@redhat.com'
+          git add -A
+          git commit -m "chore: update floorist image tag" || echo "No new changes"
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          title: 'chore: update floorist image tag to latest'

--- a/.github/workflows/checkimages.yaml
+++ b/.github/workflows/checkimages.yaml
@@ -5,7 +5,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  imagecheck:
+    name: Check baseimage
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/checkimages.yaml
+++ b/.github/workflows/checkimages.yaml
@@ -1,7 +1,7 @@
 name: Regular base image update check
 on:
   schedule:
-    - cron: "5 0 * * *"
+    - cron: "5 10 * * *"
   workflow_dispatch:
 
 jobs:

--- a/config/templated/template_params.yaml
+++ b/config/templated/template_params.yaml
@@ -7,6 +7,8 @@
 - description: Floorist exporter tool image
   name: FLOORIST_IMAGE
   value: quay.io/cloudservices/floorist
+# Note that the the tag default value is automated
+# by GitHub Action
 - description: Floorist exporter tool image tag
   name: FLOORIST_IMAGE_TAG
   value: a5d1b1b

--- a/roles/floorplan/tasks/main.yml
+++ b/roles/floorplan/tasks/main.yml
@@ -75,7 +75,7 @@
                 containers:
                 - image:
                     "{{ lookup('ansible.builtin.env', 'FLOORIST_IMAGE') | default('quay.io/cloudservices/floorist', True) }}\
-                    :{{ lookup('ansible.builtin.env', 'FLOORIST_IMAGE_TAG') | default('a5d1b1b', True) }}"
+                    :{{ lookup('ansible.builtin.env', 'FLOORIST_IMAGE_TAG') | default('latest', True) }}"
                   imagePullPolicy: IfNotPresent
                   env:
                   - name: AWS_BUCKET


### PR DESCRIPTION
Look up latest commit hash of floorist tool, check floorist image tag
existence from shortened commit, and apply it as a default
`FLOORIST_IMAGE_TAG` parameter.

[RHICOMPL-3319](https://issues.redhat.com/browse/RHICOMPL-3319)