### PR TITLE
fix(rebuilds): add image digest to avoid caching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM quay.io/operator-framework/ansible-operator:v1.33.0
 
+COPY .baseimagedigest ${HOME}
+
 USER root
 
 RUN dnf -y upgrade && \


### PR DESCRIPTION
Adds `.baseimagedigest` that is updated by automation to avoid container layer caching in case the digest changes.