### PR TITLE
fix: string formatting of global query 

### DIFF
--- a/stage_test.sh
+++ b/stage_test.sh
@@ -12,11 +12,11 @@ echo "----------------- Cronjobs found -----------------"
 echo "$NAMESPACED_CRONJOBS"
 echo "--------------------------------------------------"
 
-for NAMESPACED_CRONJOB in $NAMESPACED_CRONJOBS; do
-    NAMESPACE=$(echo $NAMESPACED_CRONJOB | awk -F ':' '{print $1}')
-    CRONJOB=$(echo $NAMESPACED_CRONJOB | awk -F ':' '{print $2}')
+for NAMESPACED_CRONJOB in "$NAMESPACED_CRONJOBS"; do
+    NAMESPACE=$(echo "$NAMESPACED_CRONJOB" | awk -F ':' '{print $1}')
+    CRONJOB=$(echo "$NAMESPACED_CRONJOB" | awk -F ':' '{print $2}')
 
-    SUCCESS=$(oc get job -l "pod=$CRONJOB" -o jsonpath='{..succeeded}{"\n"}' -n $NAMESPACE)
+    SUCCESS=$(oc get job -l "pod=$CRONJOB" -o jsonpath='{..succeeded}{"\n"}' -n "$NAMESPACE")
 
     if [[ -z "$SUCCESS" ]]; then
         echo "ERROR: cronjob $CRONJOB has not created any jobs in namespace $NAMESPACE"

--- a/stage_test.sh
+++ b/stage_test.sh
@@ -8,6 +8,10 @@ if [[ -z "$NAMESPACED_CRONJOBS" ]]; then
     exit 1
 fi
 
+echo "----------------- Cronjobs found -----------------"
+echo "$NAMESPACED_CRONJOBS"
+echo "--------------------------------------------------"
+
 for NAMESPACED_CRONJOB in $NAMESPACED_CRONJOBS; do
     NAMESPACE=$(echo $NAMESPACED_CRONJOB | awk -F ':' '{print $1}')
     CRONJOB=$(echo $NAMESPACED_CRONJOB | awk -F ':' '{print $2}')


### PR DESCRIPTION
This PR fixes a bug caused by the `--all-namespaces` option when listing resourced by their names (cluster wide non-uniqueness of names) and also contains some added logging for more verbosity.