### PR TITLE
fix(Minikube): use quay images to avoid docker.io rate limit

### DIFF
--- a/config/minikube/createbucket.yaml
+++ b/config/minikube/createbucket.yaml
@@ -35,7 +35,7 @@ spec:
             secretKeyRef:
               key: bucket
               name: minio-access
-        image: docker.io/minio/mc
+        image: quay.io/minio/mc
         name: createbucket
         command:
           - /bin/bash

--- a/config/minikube/minio.yaml
+++ b/config/minikube/minio.yaml
@@ -41,7 +41,7 @@ spec:
             secretKeyRef:
               key: aws_secret_access_key
               name: minio-access
-        image: docker.io/minio/minio:latest
+        image: quay.io/minio/minio:latest
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10


### PR DESCRIPTION
Rate limiting of docker.io makes testing harder sometimes. The images in quay are the same and are being updated at the same rate, so we will just use those.