### PR TITLE
fix(Actions): upgrade create-pull-request to v6

### DIFF
--- a/.github/workflows/checkimages.yaml
+++ b/.github/workflows/checkimages.yaml
@@ -27,7 +27,7 @@ jobs:
           git add .baseimagedigest
           git commit -m "chore(image): update base image" || echo "No new changes"
       - name: Create pull request
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@v6
         with:
           title: 'chore(image): update base image'
           branch: automation/base-image
@@ -57,7 +57,7 @@ jobs:
           git add -A
           git commit -m "chore: update floorist image tag" || echo "No new changes"
       - name: Create pull request
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@v6
         with:
           title: 'chore: update floorist image tag to latest'
           branch: automation/floorist-latest


### PR DESCRIPTION
Our GH Actions tasks seem to be stuck on an error that was fixed in v6 of create-pull-request. See the [related issue](https://github.com/peter-evans/create-pull-request/issues/2790#issuecomment-1969555770).