### PR TITLE
Correct config manager name, change Renovate naming scheme and allow frequent updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,7 @@
         "github>konflux-ci/mintmaker//config/renovate/renovate.json"
     ],
     "schedule": [
-        "* 3-10 * * 1"
+        "* 3-10 * * 1-5"
     ],
     "ignorePaths": [
       ".pre-commit-config.yaml"

--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,7 @@
     "ignorePaths": [
       ".pre-commit-config.yaml"
     ],
-    "docker": {
+    "dockerfile": {
         "enabled": true,
         "postUpdateOptions": [
             "echo {{{newValue}}} > .baseimagedigest",

--- a/renovate.json
+++ b/renovate.json
@@ -18,13 +18,13 @@
         "pinDigests": true,
         "packageRules": [
             {
-                "managers": ["dockerfile"],
-                "updateTypes": ["digest"],
+                "matchManagers": ["dockerfile"],
+                "matchUpdateTypes": ["digest"],
                 "enabled": true
             },
             {
-                "managers": ["dockerfile"],
-                "updateTypes": ["major", "minor", "patch"],
+                "matchManagers": ["dockerfile"],
+                "matchUpdateTypes": ["major", "minor", "patch"],
                 "enabled": false
             }
         ]


### PR DESCRIPTION
The temporary change in crontime is only there until I see that the updates are working correctly.