### PR TITLE
[RHINENG-26184] Bump version of create-pull-request GH action

### DIFF
--- a/.github/workflows/checkimages.yaml
+++ b/.github/workflows/checkimages.yaml
@@ -31,7 +31,7 @@ jobs:
           git add -A
           git commit -m "chore: update floorist image tag" || echo "No new changes"
       - name: Create pull request
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v8
         with:
           title: 'chore: update floorist image tag to latest'
           branch: automation/floorist-latest


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Update the create-pull-request GitHub Action version from v6 to v8 in the checkimages workflow.